### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ AI:  Found 3 Workers: api-gateway, auth-worker, image-resizer
 
 ![MCP server Cloudflare demo — listing Workers and purging cache from Claude Desktop](assets/demo.gif)
 
+<a href="https://glama.ai/mcp/servers/ofershap/mcp-server-cloudflare">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/ofershap/mcp-server-cloudflare/badge" alt="mcp-server-cloudflare MCP server" />
+</a>
+
 ## Tools
 
 | Tool               | What it does                         |


### PR DESCRIPTION
This PR adds a badge for the [mcp-server-cloudflare](https://glama.ai/mcp/servers/ofershap/mcp-server-cloudflare) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/ofershap/mcp-server-cloudflare">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/ofershap/mcp-server-cloudflare/badge" alt="mcp-server-cloudflare MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.